### PR TITLE
Hall of Fame update: use .iterator()

### DIFF
--- a/checks/tasks/update.py
+++ b/checks/tasks/update.py
@@ -76,7 +76,7 @@ def _populate_HOF(hof, model, entry_creation):
     previousscore = 0
     previoustimestamp = None
     previousreportid = None
-    for report in model.objects.all().order_by("domain", "timestamp"):
+    for report in model.objects.only("id", "domain", "timestamp", "score").order_by("domain", "timestamp").iterator():
         if previousname != report.domain and previousname is not None:
             if previousscore >= 100:
                 entry_creation(hof, previousname, previousreportid, previoustimestamp)


### PR DESCRIPTION
Hall of Fame update: use `.iterator()`
Plus fetch the used id, domain, timestamp and score.

Minor first improvement that should reduce the huge memory usage of the slow-worker on single-test.

_Disclaimer: let's see how good the CI/CD workflow is: this edit was made with the online editor, so `0` testing._